### PR TITLE
Pin numerical WordPress image version instead of referring to `latest` tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.5.1-php7.3
+FROM wordpress:5.5.1
 LABEL maintainer Automattic <oscar.lopez@automattic.com>
 
 ENV XDEBUG_PORT 9000

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Published as [automattic/wordpress-xdebug](https://hub.docker.com/r/automattic/w
 2. Merge the PR (if you're an Automattician)
 3. Using GitHub's Interface, create a release pointing to master and with the release tag matching the version you justed bumped to in the Dockerfile. e.g. so it reads `FROM wordpress:5.6.1`.
 	![image](https://user-images.githubusercontent.com/746152/94859157-7be94000-040a-11eb-8173-127d033b5238.png)
-4. That's it, now `automattic/wordpress-xdebug-latest` and `automattic/wordpress-xdebug:5.6.1` will both refer to the new build with your updates.
+4. That's it, now `automattic/wordpress-xdebug:latest` and `automattic/wordpress-xdebug:5.6.1` will both refer to the new build based on the `wordpress:5.6.1` tag.
 
 Based on previous work from [andreccosta/wordpress-xdebug](https://hub.docker.com/r/andreccosta/wordpress-xdebug.)
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,14 @@ Example configuration file `.vscode/launch.json`:
 
 Published as [automattic/wordpress-xdebug](https://hub.docker.com/r/automattic/wordpress-xdebug) in **Docker Hub**.
 
-### How to publish a new build
+## How to publish a new build
 
-Create a Pull Request bumping the version in `Dockerfile` for the `wordpress` image tag on [Automattic/wordpress-xdebug](https://github.com/Automattic/wordpress-xdebug) to get a new build done automatically. See [latest builds of automattic/wordpress-xdebug here](https://hub.docker.com/r/automattic/wordpress-xdebug/builds).
+
+1. Create a Pull Request bumping the version in `Dockerfile` for the `wordpress` image tag on [Automattic/wordpress-xdebug](https://github.com/Automattic/wordpress-xdebug) to get a new build done automatically. See [latest builds of automattic/wordpress-xdebug here](https://hub.docker.com/r/automattic/wordpress-xdebug/builds).
+2. Merge the PR (if you're an Automattician)
+3. Using GitHub's Interface, create a release pointing to master and with the release tag matching the version you justed bumped to in the Dockerfile. e.g. so it reads `FROM wordpress:5.6.1`.
+	![image](https://user-images.githubusercontent.com/746152/94859157-7be94000-040a-11eb-8173-127d033b5238.png)
+4. That's it, now `automattic/wordpress-xdebug-latest` and `automattic/wordpress-xdebug:5.6.1` will both refer to the new build with your updates.
 
 Based on previous work from [andreccosta/wordpress-xdebug](https://hub.docker.com/r/andreccosta/wordpress-xdebug.)
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example configuration file `.vscode/launch.json`:
 
 Published as [automattic/wordpress-xdebug](https://hub.docker.com/r/automattic/wordpress-xdebug) in **Docker Hub**.
 
-## How to publish a new build
+## How to publish a new build on Docker Hub
 
 
 1. Create a Pull Request bumping the version in `Dockerfile` for the `wordpress` image tag on [Automattic/wordpress-xdebug](https://github.com/Automattic/wordpress-xdebug) to get a new build done automatically. See [latest builds of automattic/wordpress-xdebug here](https://hub.docker.com/r/automattic/wordpress-xdebug/builds).

--- a/README.md
+++ b/README.md
@@ -75,8 +75,10 @@ Published as [automattic/wordpress-xdebug](https://hub.docker.com/r/automattic/w
 	![image](https://user-images.githubusercontent.com/746152/94859157-7be94000-040a-11eb-8173-127d033b5238.png)
 4. That's it, now `automattic/wordpress-xdebug:latest` and `automattic/wordpress-xdebug:5.6.1` will both refer to the new build based on the `wordpress:5.6.1` tag.
 
-Based on previous work from [andreccosta/wordpress-xdebug](https://hub.docker.com/r/andreccosta/wordpress-xdebug.)
 
 ## License
 
 GPL v2
+
+Based on previous work from [andreccosta/wordpress-xdebug](https://hub.docker.com/r/andreccosta/wordpress-xdebug.)
+

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Published as [automattic/wordpress-xdebug](https://hub.docker.com/r/automattic/w
 
 ### How to publish a new build
 
-Push anything to master on [Automattic/wordpress-xdebug](https://github.com/Automattic/wordpress-xdebug) to get a new build done automatically. See [latest builds of automattic/wordpress-xdebug here](https://hub.docker.com/r/automattic/wordpress-xdebug/builds).
+Create a Pull Request bumping the version in `Dockerfile` for the `wordpress` image tag on [Automattic/wordpress-xdebug](https://github.com/Automattic/wordpress-xdebug) to get a new build done automatically. See [latest builds of automattic/wordpress-xdebug here](https://hub.docker.com/r/automattic/wordpress-xdebug/builds).
 
 Based on previous work from [andreccosta/wordpress-xdebug](https://hub.docker.com/r/andreccosta/wordpress-xdebug.)
 


### PR DESCRIPTION
### After

![image](https://user-images.githubusercontent.com/746152/94852974-09c02d80-0401-11eb-9d9b-c7dbd9d2fc47.png)

### Before 

![image](https://user-images.githubusercontent.com/746152/94852997-13e22c00-0401-11eb-815e-38e3dd9cbd28.png)
