### PR TITLE
Release image based on wordpress:5.5.1-php7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:latest
+FROM wordpress:5.5.1-php7.3
 LABEL maintainer Automattic <oscar.lopez@automattic.com>
 
 ENV XDEBUG_PORT 9000


### PR DESCRIPTION
updates base image from `wordpress:latest` to `wordpress:5.5.1-php7.3`