### PR TITLE
Update configuration to support Xdebug3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV XDEBUG_IDEKEY docker
 RUN pecl install "xdebug" \
     && docker-php-ext-enable xdebug
 
-RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
-    echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/xdebug.ini && \
-    echo "xdebug.remote_port=${XDEBUG_PORT}" >> /usr/local/etc/php/conf.d/xdebug.ini && \
+RUN echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini && \
+    echo "xdebug.start_with_request=yes" >> /usr/local/etc/php/conf.d/xdebug.ini && \
+    echo "xdebug.client_host=host.docker.internal" >> /usr/local/etc/php/conf.d/xdebug.ini && \
+    echo "xdebug.client_port=${XDEBUG_PORT}" >> /usr/local/etc/php/conf.d/xdebug.ini && \
     echo "xdebug.idekey=${XDEBUG_IDEKEY}" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
       WORDPRESS_DB_HOST: db:3306
       WORDPRESS_DB_USER: wordpress
       WORDPRESS_DB_PASSWORD: wordpress
-      XDEBUG_CONFIG: remote_host=host.docker.internal
+      XDEBUG_CONFIG: client_host=host.docker.internal
 ```
 
 ## Usage with VSCode


### PR DESCRIPTION
Xdebug3 is installed by default and it's configuration is not compatible with the existing Xdebug2 configuration

In this PR I've updated configuration to support Xdebug3. Reference: [xdebug upgrade guide](https://xdebug.org/docs/upgrade_guide).

Things to note
* Although the default port has changed to `9003`, I continue to use `9000` to maintain backward compatibility for existing users.
* This PR sets `xdebug.client_host=host.docker.internal` within the `xdebug.ini` instead of requiring users to specify it in their `docker-compose` file as described in the readme. This makes it more likely for xdebug to work out of the box when using this image. 

Resolves #7 