### PR TITLE
Update WordPress image to use latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:5.7.0
+FROM wordpress:6.0.0
 LABEL maintainer Automattic <oscar.lopez@automattic.com>
 
 ENV XDEBUG_PORT 9000


### PR DESCRIPTION
Hi,

i've noticed the base image used in the repository is slightly outdated, i've created the following PR to address that issue.

Thank you!