### PR TITLE
Update dockerfile to always use latest image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:6.0.1
+FROM wordpress:latest
 LABEL maintainer Automattic <oscar.lopez@automattic.com>
 
 ENV XDEBUG_PORT 9000

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Usage
 
-Use the environment variable **XDEBUG_CONFIG** tu configure the XDebug PHP extension.
+Use the environment variable **XDEBUG_CONFIG** to configure the XDebug PHP extension.
 
 ## Docker Compose
 


### PR DESCRIPTION
Hi,

i've created the following PR which updates the Dockerfile to always pull the latest version of the WordPress image.

This will also fix an issue which caused the run command to fail due to xdebug not being compatible anymore with PHP 7.4. `pecl/xdebug requires PHP (version >= 8.0.0, version <= 8.2.99), installed version is 7.4.30`

As part of this i've also commited a fix for a minor typo in the readme.

Thank you!
 